### PR TITLE
Fix Stripe redirection to main page

### DIFF
--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -4,6 +4,7 @@ import {
 } from "@/lib/payment-helpers";
 import { NextRequest, NextResponse } from "next/server";
 import Stripe from "stripe";
+import { redirect } from "next/navigation";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
 
@@ -35,6 +36,11 @@ export async function POST(req: NextRequest) {
 
         //connect to the db create or update user
         await handleCheckoutSessionCompleted({ session, stripe });
+
+        // Redirect to the main page upon successful completion of the 30 days demo selection
+        if (session.mode === "subscription" && session.subscription) {
+          return NextResponse.redirect("/");
+        }
         break;
       }
       case "customer.subscription.deleted": {


### PR DESCRIPTION
Add redirection logic to handle demo selection on Stripe page.

* Import `redirect` from "next/navigation" in `app/api/payments/route.ts`.
* Add redirection to the main page upon successful completion of the 30 days demo selection in the `POST` method of `app/api/payments/route.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abhiya492/motion-ai/pull/1?shareId=672d5103-733a-494d-9ba7-8fe0d631aac5).